### PR TITLE
Updated Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Both methods expect the same arguments.
     from my_app.models import Charge
 
     factory = Factory()
-    factory.build(Charge[, count, initial])
+    factory.build(Charge[, count] | [, initial])
 
 
 Usage
@@ -144,7 +144,7 @@ Example 3: Model w/ multiple count::
 
 Note:
 
-    Example 3 will a list with *count* charge objects.  All will be unique and
+    Example 3 will a list with 5 *charge* objects.  All will be unique and
     contain random data.
 
 Example 4: Model w/ single count and initial::
@@ -154,20 +154,19 @@ Example 4: Model w/ single count and initial::
     from my_app.models import Charge
 
     factory = Factory()
-    count = 1
     initial = {
         'amount': '50',
         'description': 'test description',
     }
-    charge = factory.create(Charge, count, initial)
+    charge = factory.create(Charge, initial)
 
 
 Note:
 
     Example 4 will create a single charge object with the *amount* and
     *description* fields containing the data provided in the *initial*
-    dictionary.  It should be emphasized that you must provide a *count* if you
-    intend to provide *initial* data.
+    dictionary.  It should be emphasized that you must provide either *count*
+    or *initial* data.
 
 Example 5: Model w/ multi count and single initial::
 
@@ -181,13 +180,16 @@ Example 5: Model w/ multi count and single initial::
         'amount': '50',
         'description': 'test description',
     }
-    charges = factory.create(Charge, count, initial)
+    initial_list = list()
+    for _ in itertools.repeat(None, count):
+        initial_list.append(initial)
+    charges = factory.create(Charge, initial_list)
 
 Note:
 
     Example 5 will create two unique charge objects passed back in the
-    *charges* list.  Both objects will contain the *initial* data.  All other
-    fields will be randomly generated.
+    *charges* list.  Both objects will contain the same *initial* data.  All
+    other fields will be randomly generated.
 
 Example 6: Model /w multi count and multi intial::
 
@@ -196,7 +198,6 @@ Example 6: Model /w multi count and multi intial::
     from my_app.models import Charge
 
     factory = Factory()
-    count = 2
     initial1 = {
         'amount': '50',
         'description': 'test description 1',
@@ -206,14 +207,13 @@ Example 6: Model /w multi count and multi intial::
         'description': 'test description 2',
     }
     initial_list = [initial1, initial2]
-    charges = factory.create(Charge, count, initial_list)
+    charges = factory.create(Charge, initial_list)
 
 Note:
 
     Example 6 will create two unique *Charge* objects passed back in the
     *charges* list.  The first item will contain *initial1* data and the second
-    will contain *initial2* data.  It should be emphasized that
-    *len(initial_list) == count* should evaluate *True*.
+    will contain *initial2* data.
 
 Example 7: Multi Model Trivial::
 
@@ -260,11 +260,17 @@ Example 9: Multi Model w/ counts and initial::
         'amount': '50',
         'description': 'test description 1',
     }
+    initial_list1 = list()
+    for _ in itertools.repeat(None, count1):
+        initial_list.append(initial1)
     initial2 = {
         'account_balance': '10',
         'email': 'test@example.com',
     }
-    args = ((Charge, count1, initial1), (Customer, count2, initial2))
+    initial_list2 = list()
+    for _ in itertools.repeat(None, count2):
+        initial_list2.append(initial)
+    args = ((Charge, initial_list1), (Customer, initial_list2))
     objs = factory.create(*args)
 
 Note:
@@ -304,10 +310,10 @@ Example 10: Multi Model w/ counts and multi initial::
     }
     initial1_list = [initial1_1, initial1_2]
     initial2_list = [initial2_1, initial2_2, initial2_3]
-    args = ((Charge, count1, initial1_list), (Customer, count2, initial2_list))
+    args = ((Charge, initial1_list), (Customer, initial2_list))
     objs = factory.create(*args)
 
 Note:
 
-    Example 10 will create two *Charge* objects one for each *initia1_x*
-    followed by three *Customer* objects one for each *initial2_x*.
+    Example 10 will create two *Charge* objects, one for each *initia1_x*,
+    followed by three *Customer* objects, one for each *initial2_x*.

--- a/fixtureless/factory.py
+++ b/fixtureless/factory.py
@@ -9,12 +9,8 @@ from fixtureless.utils import list_get
 
 
 class Factory(object):
-    def _verify_kwargs(self, vals, count):
+    def _verify_kwargs(self, vals):
         if isinstance(vals, (list, tuple)):
-            if count != len(vals):
-                msg = 'The fixtureless factory cannot build {} objects with' \
-                      ' {} kwargs values.'.format(count, len(vals))
-                raise exceptions.InvalidArguments(msg)
             for val in vals:
                 if isinstance(val, dict) or val is None:
                     continue
@@ -26,6 +22,20 @@ class Factory(object):
                   ' and was given type {}'.format(type(vals))
             raise exceptions.InvalidArguments(msg)
 
+    def _handle_second_arg(self, *args):
+        sec_arg = list_get(args, 1)
+        count = 1
+        kwargs = None
+        if isinstance(sec_arg, int):
+            count = sec_arg
+        elif isinstance(sec_arg, (list, tuple)):
+            kwargs = sec_arg
+            count = len(kwargs)
+        elif isinstance(sec_arg, dict):
+            kwargs = sec_arg
+        return kwargs, count
+
+
     def _resolve_args(self, *args):
         try:
             if inspect.isclass(args[0]) and issubclass(args[0], Model):
@@ -36,9 +46,8 @@ class Factory(object):
             msg = 'The fixtureless factory expects a Django model ({}) as' \
                   ' the first argument.'.format(type(Model))
             raise exceptions.InvalidArguments(msg)
-        count = list_get(args, 1, 1)
-        kwargs = list_get(args, 2)
-        self._verify_kwargs(kwargs, count)
+        kwargs, count = self._handle_second_arg(*args)
+        self._verify_kwargs(kwargs)
         return model, count, kwargs
 
     def _build_instance(self, model, kwargs, objs, create):

--- a/fixtureless/tests/test_django_project/test_django_project/test_app/tests/factory.py
+++ b/fixtureless/tests/test_django_project/test_django_project/test_app/tests/factory.py
@@ -1,3 +1,4 @@
+import itertools
 from decimal import Decimal
 
 from django.test import TestCase
@@ -16,44 +17,36 @@ class FactoryTest(TestCase):
         with self.assertRaises(InvalidArguments) as _:
             factory._resolve_args('wrong_val')
 
-        model, count, kwargs = factory._resolve_args(ModelOne)
+        model, count, initial = factory._resolve_args(ModelOne)
         self.assertEqual(model, ModelOne)
         self.assertIsInstance(count, int)
-        self.assertIsNone(kwargs)
+        self.assertIsNone(initial)
 
     def test_verify_kwargs(self):
         factory = Factory()
 
         # invalid kwarg type
         val = 'invalid type'
-        count = 0
         with self.assertRaises(InvalidArguments) as _:
-            factory._verify_kwargs(val, count)
+            factory._verify_kwargs(val)
 
         # invalid kwarg type in list
         val = ['invalid type']
         with self.assertRaises(InvalidArguments) as _:
-            factory._verify_kwargs(val, count)
-
-        # valid type, wrong length
-        val = [{'valid': 'type'}]
-        with self.assertRaises(InvalidArguments) as _:
-            factory._verify_kwargs(val, count)
+            factory._verify_kwargs(val)
 
         # valid kwarg type no list
         val = {'valid': 'type'}
-        factory._verify_kwargs(val, count)
+        factory._verify_kwargs(val)
 
-        # valid type, correct length
+        # valid type
         val = [{'valid': 'type'}]
-        count = 1
-        factory._verify_kwargs(val, count)
+        factory._verify_kwargs(val)
 
         # valid type, invalid type, correct length
         val = [{'valid': 'type'}, 'invalid type']
-        count = 2
         with self.assertRaises(InvalidArguments) as _:
-            factory._verify_kwargs(val, count)
+            factory._verify_kwargs(val)
 
     # Model trivial
     def test_build_trivial(self):
@@ -73,57 +66,59 @@ class FactoryTest(TestCase):
     def test_build_with_multi_count(self):
         factory = Factory()
         count = 2
-        args = (ModelOne, count)
-        models = factory.build(*args)
+        models = factory.build(ModelOne, count)
         self.assertEqual(len(models), count)
         self.assertIsInstance(models[0], ModelOne)
         self.assertIsInstance(models[1], ModelOne)
         self.assertNotEqual(models[0], models[1])
 
-    # Model w/ single count and kwargs
-    def test_build_with_count_and_kwargs(self):
+    # Model w/ single count and initial
+    def test_build_with_count_and_initial(self):
         factory = Factory()
         count = 1
-        kwargs = {
+        initial = {
             'decimal_field': Decimal('10.00')
         }
-        args = (ModelOne, count, kwargs)
+        args = (ModelOne, initial)
         model = factory.build(*args)
         self.assertIsInstance(model, ModelOne)
-        self.assertEqual(model.decimal_field, kwargs['decimal_field'])
+        self.assertEqual(model.decimal_field, initial['decimal_field'])
 
-    # Model w/ multi count and single kwargs
-    def test_build_with_multi_count_and_single_kwargs(self):
+    # Model w/ multi count and single initial
+    def test_build_with_multi_count_and_single_initial(self):
         factory = Factory()
         count = 2
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
-        args = (ModelOne, count, kwargs1)
+        initial_list = list()
+        for _ in itertools.repeat(None, count):
+            initial_list.append(initial1)
+        args = (ModelOne, initial_list)
         models = factory.build(*args)
         self.assertEqual(len(models), count)
         self.assertIsInstance(models[0], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[1].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial1['decimal_field'])
 
-    # Model w/ multi count and multi kwargs
-    def test_build_with_multi_count_and_multi_kwargs(self):
+    # Model w/ multi count and multi initial
+    def test_build_with_multi_count_and_multi_initial(self):
         factory = Factory()
         count = 2
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
-        kwargs2 = {
+        initial2 = {
             'decimal_field': Decimal('8.00')
         }
-        args = (ModelOne, count, [kwargs1, kwargs2])
+        args = (ModelOne, [initial1, initial2])
         models = factory.build(*args)
         self.assertEqual(len(models), count)
         self.assertIsInstance(models[0], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[1].decimal_field, kwargs2['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial2['decimal_field'])
 
     # Multi Model Trivial
     def test_build_with_multi_model_trivial(self):
@@ -159,80 +154,82 @@ class FactoryTest(TestCase):
         self.assertIsInstance(models[3], ModelTwo)
         self.assertIsInstance(models[4], ModelTwo)
 
-    # Multi Model w/ single count and kwargs
-    def test_build_with_multi_model_and_single_count_and_single_kwargs(self):
+    # Multi Model w/ single count and initial
+    def test_build_with_multi_model_and_single_count_and_single_initial(self):
         factory = Factory()
-        count1 = 1
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
-        count2 = 1
-        kwargs2 = {
+        initial2 = {
             'char_field': 'test value'
         }
-        args = ((ModelOne, count1, kwargs1), (ModelTwo, count2, kwargs2))
+        args = ((ModelOne, initial1), (ModelTwo, initial2))
         models = factory.build(*args)
         self.assertIsInstance(models[0], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
 
         self.assertIsInstance(models[1], ModelTwo)
-        self.assertEqual(models[1].char_field, kwargs2['char_field'])
+        self.assertEqual(models[1].char_field, initial2['char_field'])
 
-    # Multi Model w/ multi count and single kwargs
-    def test_build_with_multi_model_and_multi_count_and_single_kwargs(self):
+    # Multi Model w/ multi count and single initial
+    def test_build_with_multi_model_and_multi_count_and_single_initial(self):
         factory = Factory()
         count1 = 2
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
+        initial_list1 = list()
+        for _ in itertools.repeat(None, count1):
+            initial_list1.append(initial1)
         count2 = 3
-        kwargs2 = {
+        initial2 = {
             'char_field': 'test value'
         }
-        args = ((ModelOne, count1, kwargs1), (ModelTwo, count2, kwargs2))
+        initial_list2 = list()
+        for _ in itertools.repeat(None, count2):
+            initial_list2.append(initial2)
+        args = ((ModelOne, initial_list1), (ModelTwo, initial_list2))
         models = factory.build(*args)
         self.assertEqual(len(models), count1 + count2)
         self.assertIsInstance(models[0], ModelOne)
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
-        self.assertEqual(models[1].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial1['decimal_field'])
 
         self.assertIsInstance(models[2], ModelTwo)
         self.assertIsInstance(models[3], ModelTwo)
         self.assertIsInstance(models[4], ModelTwo)
-        self.assertEqual(models[2].char_field, kwargs2['char_field'])
-        self.assertEqual(models[3].char_field, kwargs2['char_field'])
-        self.assertEqual(models[4].char_field, kwargs2['char_field'])
+        self.assertEqual(models[2].char_field, initial2['char_field'])
+        self.assertEqual(models[3].char_field, initial2['char_field'])
+        self.assertEqual(models[4].char_field, initial2['char_field'])
 
-    # Multi Model w/ multi count and multi kwargs
-    def test_build_with_multi_model_and_multi_count_and_multi_kwargs(self):
+    # Multi Model w/ multi count and multi initial
+    def test_build_with_multi_model_and_multi_count_and_multi_initial(self):
         factory = Factory()
-        count1 = 2
-        kwargs1_1 = {
+        initial1_1 = {
             'decimal_field': Decimal('10.00')
         }
-        kwargs1_2 = {
+        initial1_2 = {
             'decimal_field': Decimal('8.00')
         }
-        count2 = 2
-        kwargs2_1 = {
+        initial2_1 = {
             'char_field': 'test value 1'
         }
-        kwargs2_2 = {
+        initial2_2 = {
             'char_field': 'test value 2'
         }
-        args = ((ModelOne, count1, [kwargs1_1, kwargs1_2]),
-                (ModelTwo, count2, [kwargs2_1, kwargs2_2]))
+        args = ((ModelOne, [initial1_1, initial1_2]),
+                (ModelTwo, [initial2_1, initial2_2]))
         models = factory.build(*args)
-        self.assertEqual(len(models), count1 + count2)
+        self.assertEqual(len(models), 4)
         self.assertIsInstance(models[0], ModelOne)
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1_1['decimal_field'])
-        self.assertEqual(models[1].decimal_field, kwargs1_2['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1_1['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial1_2['decimal_field'])
         self.assertIsInstance(models[2], ModelTwo)
         self.assertIsInstance(models[3], ModelTwo)
-        self.assertEqual(models[2].char_field, kwargs2_1['char_field'])
-        self.assertEqual(models[3].char_field, kwargs2_2['char_field'])
+        self.assertEqual(models[2].char_field, initial2_1['char_field'])
+        self.assertEqual(models[3].char_field, initial2_2['char_field'])
 
     # Model trivial
     def test_create_trivial(self):
@@ -277,68 +274,70 @@ class FactoryTest(TestCase):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), count)
 
-    # Model w/ single count and kwargs
-    def test_create_with_count_and_kwargs(self):
+    # Model w/ single count and initial
+    def test_create_with_count_and_initial(self):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), 0)
 
         factory = Factory()
-        count = 1
-        kwargs = {
+        initial = {
             'decimal_field': Decimal('10.00')
         }
-        args = (ModelOne, count, kwargs)
+        args = (ModelOne, initial)
         model = factory.create(*args)
         self.assertIsInstance(model, ModelOne)
-        self.assertEqual(model.decimal_field, kwargs['decimal_field'])
+        self.assertEqual(model.decimal_field, initial['decimal_field'])
 
         models = ModelOne.objects.all()
-        self.assertEqual(len(models), count)
+        self.assertEqual(len(models), 1)
 
-    # Model w/ multi count and single kwargs
-    def test_create_with_multi_count_and_single_kwargs(self):
+    # Model w/ multi count and single initial
+    def test_create_with_multi_count_and_single_initial(self):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), 0)
 
         factory = Factory()
         count = 2
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
-        args = (ModelOne, count, kwargs1)
+        initial_list = list()
+        for _ in itertools.repeat(None, count):
+            initial_list.append(initial1)
+
+        args = (ModelOne, initial_list)
         models = factory.create(*args)
         self.assertEqual(len(models), count)
         self.assertIsInstance(models[0], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[1].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial1['decimal_field'])
 
         models = ModelOne.objects.all()
         self.assertEqual(len(models), count)
 
-    # Model w/ multi count and multi kwargs
-    def test_create_with_multi_count_and_multi_kwargs(self):
+    # Model w/ multi count and multi initial
+    def test_create_with_multi_count_and_multi_initial(self):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), 0)
 
         factory = Factory()
-        count = 2
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
-        kwargs2 = {
+        initial2 = {
             'decimal_field': Decimal('8.00')
         }
-        args = (ModelOne, count, [kwargs1, kwargs2])
+        args = (ModelOne, [initial1, initial2])
         models = factory.create(*args)
-        self.assertEqual(len(models), count)
+        self.assertEqual(len(models), 2)
         self.assertIsInstance(models[0], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[1].decimal_field, kwargs2['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial2['decimal_field'])
 
         models = ModelOne.objects.all()
-        self.assertEqual(len(models), count)
+        self.assertEqual(len(models), 2)
 
     # Multi Model Trivial
     def test_create_with_multi_model_trivial(self):
@@ -409,40 +408,38 @@ class FactoryTest(TestCase):
         models = ModelTwo.objects.all()
         self.assertEqual(len(models), count2)
 
-    # Multi Model w/ single count and kwargs
-    def test_create_with_multi_model_and_single_count_and_single_kwargs(self):
+    # Multi Model w/ single count and initial
+    def test_create_with_multi_model_and_single_count_and_single_initial(self):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), 0)
         models = ModelTwo.objects.all()
         self.assertEqual(len(models), 0)
 
         factory = Factory()
-        count1 = 1
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
-        count2 = 1
-        kwargs2 = {
+        initial2 = {
             'char_field': 'test value'
         }
-        args = ((ModelOne, count1, kwargs1), (ModelTwo, count2, kwargs2))
+        args = ((ModelOne, initial1), (ModelTwo, initial2))
         models = factory.create(*args)
         self.assertIsInstance(models[0], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
 
         self.assertIsInstance(models[1], ModelTwo)
-        self.assertEqual(models[1].char_field, kwargs2['char_field'])
+        self.assertEqual(models[1].char_field, initial2['char_field'])
 
         # Since ModelTwo has a FK and OneToOne to ModelOne we expect:
-        # 1 for the count in the factory models (count1)
-        # 1 for each OneToOne fields (count2)
+        # 1 for the count in the factory models
+        # 1 for each OneToOne fields
         models = ModelOne.objects.all()
-        self.assertEqual(len(models), count1 + count2)
+        self.assertEqual(len(models), 2)
         models = ModelTwo.objects.all()
-        self.assertEqual(len(models), count2)
+        self.assertEqual(len(models), 1)
 
-    # Multi Model w/ multi count and single kwargs
-    def test_create_with_multi_model_and_multi_count_and_single_kwargs(self):
+    # Multi Model w/ multi count and single initial
+    def test_create_with_multi_model_and_multi_count_and_single_initial(self):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), 0)
         models = ModelTwo.objects.all()
@@ -450,27 +447,33 @@ class FactoryTest(TestCase):
 
         factory = Factory()
         count1 = 2
-        kwargs1 = {
+        initial1 = {
             'decimal_field': Decimal('10.00')
         }
+        initial_list1 = list()
+        for _ in itertools.repeat(None, count1):
+            initial_list1.append(initial1)
         count2 = 3
-        kwargs2 = {
+        initial2 = {
             'char_field': 'test value'
         }
-        args = ((ModelOne, count1, kwargs1), (ModelTwo, count2, kwargs2))
+        initial_list2 = list()
+        for _ in itertools.repeat(None, count2):
+            initial_list2.append(initial2)
+        args = ((ModelOne, initial_list1), (ModelTwo, initial_list2))
         models = factory.create(*args)
         self.assertEqual(len(models), count1 + count2)
         self.assertIsInstance(models[0], ModelOne)
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1['decimal_field'])
-        self.assertEqual(models[1].decimal_field, kwargs1['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial1['decimal_field'])
 
         self.assertIsInstance(models[2], ModelTwo)
         self.assertIsInstance(models[3], ModelTwo)
         self.assertIsInstance(models[4], ModelTwo)
-        self.assertEqual(models[2].char_field, kwargs2['char_field'])
-        self.assertEqual(models[3].char_field, kwargs2['char_field'])
-        self.assertEqual(models[4].char_field, kwargs2['char_field'])
+        self.assertEqual(models[2].char_field, initial2['char_field'])
+        self.assertEqual(models[3].char_field, initial2['char_field'])
+        self.assertEqual(models[4].char_field, initial2['char_field'])
 
         # Since ModelTwo has a FK and OneToOne to ModelOne we expect:
         # 1 for the count in the factory models (count1)
@@ -480,45 +483,43 @@ class FactoryTest(TestCase):
         models = ModelTwo.objects.all()
         self.assertEqual(len(models), count2)
 
-    # Multi Model w/ multi count and multi kwargs
-    def test_create_with_multi_model_and_multi_count_and_multi_kwargs(self):
+    # Multi Model w/ multi count and multi initial
+    def test_create_with_multi_model_and_multi_count_and_multi_initial(self):
         models = ModelOne.objects.all()
         self.assertEqual(len(models), 0)
         models = ModelTwo.objects.all()
         self.assertEqual(len(models), 0)
 
         factory = Factory()
-        count1 = 2
-        kwargs1_1 = {
+        initial1_1 = {
             'decimal_field': Decimal('10.00')
         }
-        kwargs1_2 = {
+        initial1_2 = {
             'decimal_field': Decimal('8.00')
         }
-        count2 = 2
-        kwargs2_1 = {
+        initial2_1 = {
             'char_field': 'test value 1'
         }
-        kwargs2_2 = {
+        initial2_2 = {
             'char_field': 'test value 2'
         }
-        args = ((ModelOne, count1, [kwargs1_1, kwargs1_2]),
-                (ModelTwo, count2, [kwargs2_1, kwargs2_2]))
+        args = ((ModelOne, [initial1_1, initial1_2]),
+                (ModelTwo, [initial2_1, initial2_2]))
         models = factory.create(*args)
-        self.assertEqual(len(models), count1 + count2)
+        self.assertEqual(len(models), 4)
         self.assertIsInstance(models[0], ModelOne)
         self.assertIsInstance(models[1], ModelOne)
-        self.assertEqual(models[0].decimal_field, kwargs1_1['decimal_field'])
-        self.assertEqual(models[1].decimal_field, kwargs1_2['decimal_field'])
+        self.assertEqual(models[0].decimal_field, initial1_1['decimal_field'])
+        self.assertEqual(models[1].decimal_field, initial1_2['decimal_field'])
         self.assertIsInstance(models[2], ModelTwo)
         self.assertIsInstance(models[3], ModelTwo)
-        self.assertEqual(models[2].char_field, kwargs2_1['char_field'])
-        self.assertEqual(models[3].char_field, kwargs2_2['char_field'])
+        self.assertEqual(models[2].char_field, initial2_1['char_field'])
+        self.assertEqual(models[3].char_field, initial2_2['char_field'])
 
         # Since ModelTwo has a FK and OneToOne to ModelOne we expect:
         # 1 for the count in the factory models (count1)
         # 1 for each OneToOne fields (count2)
         models = ModelOne.objects.all()
-        self.assertEqual(len(models), count1 + count2)
+        self.assertEqual(len(models), 4)
         models = ModelTwo.objects.all()
-        self.assertEqual(len(models), count2)
+        self.assertEqual(len(models), 2)


### PR DESCRIPTION
The interface to the Factory required a count equal to the number of initial dictionaries given.  This interface was redundant.  Therefore the interface has changed to accept either a count or an initial dictionary or a list of initial dictionaries.
