### PR TITLE
added import fix for django 1.4 exceptions

### DIFF
--- a/fixtureless/generator.py
+++ b/fixtureless/generator.py
@@ -9,7 +9,12 @@ from django.db import models
 from django.db import connection
 from django.db.models.fields import NOT_PROVIDED
 from django.conf import settings
-from django.core.exceptions import SuspiciousFileOperation
+try:
+    from django.core.exceptions import SuspiciousFileOperation
+except ImportError:
+    # For django 1.4
+    from django.core.exceptions import SuspiciousOperation as\
+            SuspiciousFileOperation
 
 from fixtureless import constants
 


### PR DESCRIPTION
In django 1.4, the [exception](https://docs.djangoproject.com/en/1.4/ref/exceptions/#suspiciousoperation) was known as `SuspiciousOperation` instead of `SuspiciousFileOperation`.

I added an (meta?) exception for the import error which will import the 1.4 version as the class name used in the `generator.py` code.
